### PR TITLE
Fix requirements after socketio client refactoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
-python-socketio[client]==5.2.1; python_version == "2.7"
-python-socketio[client]==5.3.0; python_version == "3.5"
-python-socketio[client]==5.4.0; python_version > "3.5"
-requests==2.26.0
-deprecated==1.2.13
+-e .[dev,test]

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,11 @@ classifiers =
 zip_safe = False
 packages = find:
 install_requires =
-    socketio-client==0.7.2
-    deprecated==1.1.0
-    requests==2.24.0
+    python-socketio[client]==5.2.1; python_version == "2.7"
+    python-socketio[client]==5.3.0; python_version == "3.5"
+    python-socketio[client]==5.4.0; python_version > "3.5"
+    deprecated==1.2.13
+    requests==2.26.0
 
 [options.packages.find]
 # ignore gazutest directory

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python
+import ast
+import re
+import os
+
 from setuptools import setup
 
-from gazu.__version__ import __version__
+
+# We hack our way into getting the version from gazu without imports :
+# running gazu/__init__.py would cause errors due to the import of dependencies yet to be installed
+versionpath = os.path.join(os.path.dirname(__file__), "gazu/__version__.py")
+with open(versionpath, "r") as file:
+    __version__ = ast.literal_eval(re.search('__version__ *= *(\S+)', file.read()).group(1))
 
 setup()


### PR DESCRIPTION
**Problem**
After installing gazu in a clean environment through *pip*, we get an import error (see #198)

```(venv) C:\Users\aboellinger>python -c "import gazu"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\aboellinger\venv\lib\site-packages\gazu\__init__.py", line 4, in <module>
    from . import events
  File "C:\Users\aboellinger\venv\lib\site-packages\gazu\events.py", line 4, in <module>
    import socketio
ModuleNotFoundError: No module named 'socketio'
```

**Solution**
- Having a single source of truth regarding dependencies (`setup.cfg`, with requirements.txt "referencing it" with `-e .`)
- Changes also introduced to `setup.py` to avoid importing gazu dependencies before we install them. 